### PR TITLE
feat: Support executable vault password scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.4.0](https://github.com/ipierre1/ansible-vault-vscode/compare/v1.3.1...v1.4.0) (2026-04-30)
+
+### Features
+
+* Support dynamic executable `vault_password_file` scripts for path-based password resolution.
+* Graceful decryption fallback loop to prompt users manually if an invalid password is provided.
+
 ## [1.3.1](https://github.com/ipierre1/ansible-vault-vscode/compare/v1.3.0...v1.3.1) (2025-10-12)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -78,6 +78,49 @@ The extension employs a path search algorithm that starts from the current file'
 
 Once an `ansible.cfg` file is found, the extension extracts relevant configuration settings such as `vault_password_file` and `vault_identity_list`. These settings are then used to determine the password file and vault identities needed for encryption and decryption.
 
+### Advanced: Dynamic Passwords for Multi-Environment Projects
+
+<details>
+<summary><strong>How to automatically use different passwords based on the file's path</strong></summary>
+
+If your Ansible repository manages multiple environments (e.g., `prod` vs `test`), you likely use different vault passwords for each. Instead of typing the password manually every time you switch between environment folders, you can automate this by providing an executable script as your `vault_password_file`.
+
+When the configured `vault_password_file` (in your `ansible.cfg` or VS Code settings) is an executable script (e.g., starts with `#!/usr/bin/env bash` and has `+x` permissions), this extension will execute it. The filepath (relative to the project root) is passed as the first argument, allowing your script to determine and output the correct password via `stdout`. Any diagnostic output written to `stderr` is logged to the extension's VS Code output channel.
+
+**Example Setup:**
+
+1. Set `ansible.cfg`'s `vault_password_file` to `./vault_password.sh`.
+2. Create the file `vault_password.sh` in your project root with the contents below.
+3. Make the script executable by running `chmod +x vault_password.sh`.
+4. Set the `ANSIBLE_VAULT_PROD` and `ANSIBLE_VAULT_TEST` environment variables in your terminal prior to starting VS Code.
+5. When you decrypt an Ansible vault string, the extension will execute the script and use the output as the `ANSIBLE_VAULT_PASSWORD`.
+
+**`vault_password.sh`:**
+```bash
+#!/usr/bin/env bash
+
+# When set, use ANSIBLE_VAULT_PROD for prod files (matching ${PROD_FILE_SUBSTRING_MATCH}), and ANSIBLE_VAULT_TEST for non-prod files; falling back to ANSIBLE_VAULT_PASSWORD
+
+PROD_FILE_SUBSTRING_MATCH="environment/prod/"
+PROD_FILE="$(dirname "${TARGET_FILE}" | grep -q "${PROD_FILE_SUBSTRING_MATCH}" && echo true)"
+TARGET_FILE="$*"
+
+if [ ! -z "${ANSIBLE_VAULT_PROD}" ] && [ ! -z "${PROD_FILE}" ]; then # Prod vault password + Prod file
+    echo "Production file path, using Production Ansible Password value" >&2
+    [ ! -z "${ANSIBLE_VAULT_PASSWORD}" ] && [ "${ANSIBLE_VAULT_PASSWORD}" != "${ANSIBLE_VAULT_PROD}" ] && echo "WARNING: ANSIBLE_VAULT_PASSWORD is set to a different value that ANSIBLE_VAULT_PROD" >&2
+    echo "${ANSIBLE_VAULT_PROD}"
+elif [ ! -z "${ANSIBLE_VAULT_TEST}" ] && [ -z "${PROD_FILE}" ]; then # Non-prod vault password + Non-prod file
+    echo "Non-prod file path, using Non-prod Ansible Password value" >&2
+    [ -z ${ANSIBLE_VAULT_PASSWORD} ] && [ "${ANSIBLE_VAULT_PASSWORD}" != "${ANSIBLE_VAULT_TEST}" ] && echo "WARNING: ANSIBLE_VAULT_PASSWORD is set to a different value that ANSIBLE_VAULT_TEST" >&2
+    echo "${ANSIBLE_VAULT_TEST}"
+else # Fallback to normal environment vault password
+    echo "Providing ANSIBLE_VAULT_PASSWORD value from environment" >&2
+    [ -z "${ANSIBLE_VAULT_PASSWORD}" ] && echo "WARNING: ANSIBLE_VAULT_PASSWORD is blank!" >&2 || echo "using ANSIBLE_VAULT_PASSWORD" >&2
+    echo "${ANSIBLE_VAULT_PASSWORD}"
+fi
+```
+</details>
+
 ## Additional Information
 
 - [Ansible®](https://docs.ansible.com/ansible/latest/dev_guide/style_guide/trademarks.html) is a registered trademark of [RedHat®](https://www.redhat.com/en).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ansible-vault-vscode",
-  "version": "1.0.14",
+  "version": "1.4.0",
   "publisher": "ipierre1",
   "engines": {
     "vscode": "^1.106.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,7 +161,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Resolve password
     let pass: string | undefined;
-
     if (config.keyFile || config.keyPass) {
       if (config.keyFile) {
         const keyFile = (config.keyFile as string).trim();
@@ -191,123 +190,138 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }
 
-    if (!pass) {
-      pass = await vscode.window.showInputBox({
-        prompt: isRekey
-          ? "Enter the CURRENT ansible-vault password (to decrypt):"
-          : "Enter the ansible-vault password:",
-        password: true,
-      });
-    }
+    let actionDone = false;
+    while (!actionDone) {
+      if (!pass) {
+        pass = await vscode.window.showInputBox({
+          prompt: isRekey
+            ? "Enter the CURRENT ansible-vault password (to decrypt):"
+            : "Enter the ansible-vault password:",
+          password: true,
+        });
+      }
 
-    if (!pass) {
-      vscode.window.showWarningMessage(
-        "No password provided. Operation cancelled.",
-      );
-      return;
-    }
-
-    // Perform encrypt / decrypt on selection or full file
-    if (selectedText) {
-      const type = getInlineTextType(selectedText);
-
-      if (type === "plaintext") {
-        logs.appendLine(`🔒 Encrypt selected text`);
-        const status = vscode.window.setStatusBarMessage(
-          "$(loading~spin) Encrypting...",
+      if (!pass) {
+        vscode.window.showWarningMessage(
+          "No password provided. Operation cancelled.",
         );
-        const encryptedText = await encrypt(selectedText, pass, vaultId);
-        status.dispose();
-        if (encryptedText) {
-          await editor.edit((editBuilder) => {
-            editBuilder.replace(
-              selection,
-              reindentText(
-                encryptedText,
-                getIndentationLevel(editor, selection),
-                Number(editor.options.tabSize),
-              ),
-            );
-          });
-          if (!isRekey) {
-            vscode.window.showInformationMessage("Selection encrypted.");
+        return;
+      }
+
+      // Perform encrypt / decrypt on selection or full file
+      if (selectedText) {
+        const type = getInlineTextType(selectedText);
+
+        if (type === "plaintext") {
+          logs.appendLine(`🔒 Encrypt selected text`);
+          const status = vscode.window.setStatusBarMessage(
+            "$(loading~spin) Encrypting...",
+          );
+          const encryptedText = await encrypt(selectedText, pass, vaultId);
+          status.dispose();
+          if (encryptedText) {
+            await editor.edit((editBuilder) => {
+              editBuilder.replace(
+                selection,
+                reindentText(
+                  encryptedText,
+                  getIndentationLevel(editor, selection),
+                  Number(editor.options.tabSize),
+                ),
+              );
+            });
+            if (!isRekey) {
+              vscode.window.showInformationMessage("Selection encrypted.");
+            }
           }
-        }
-      } else if (type === "encrypted") {
-        logs.appendLine(`🔓 Decrypt selected text`);
-        const status = vscode.window.setStatusBarMessage(
-          "$(loading~spin) Decrypting...",
-        );
-        const decryptedText = await decrypt(
-          selectedText
+          actionDone = true;
+        } else if (type === "encrypted") {
+          logs.appendLine(`🔓 Decrypt selected text`);
+          const status = vscode.window.setStatusBarMessage(
+            "$(loading~spin) Decrypting...",
+          );
+          const vaultTextToDecrypt = selectedText
             .replace("!vault |", "")
             .trim()
-            .replace(/[^\S\r\n]+/gm, ""),
-          pass,
-          vaultId,
-        );
-        status.dispose();
-        if (decryptedText === undefined) {
-          vscode.window.showErrorMessage("Decryption failed: Invalid Vault");
-        } else {
-          await editor.edit((editBuilder) => {
-            editBuilder.replace(selection, decryptedText);
-          });
-          if (!isRekey) {
-            vscode.window.showInformationMessage("Selection decrypted.");
-          }
-        }
-      }
-    } else {
-      const content = editor.document.getText();
-      const type = getTextType(content);
+            .replace(/[^\S\r\n]+/gm, "");
 
-      if (type === "plaintext") {
-        logs.appendLine(`🔒 Encrypt entire file`);
-        const status = vscode.window.setStatusBarMessage(
-          "$(loading~spin) Encrypting...",
-        );
-        const encryptedText = await encrypt(content, pass, vaultId);
-        status.dispose();
-        if (encryptedText) {
-          await editor.edit((builder) => {
-            builder.replace(
-              new vscode.Range(
-                doc.lineAt(0).range.start,
-                doc.lineAt(doc.lineCount - 1).range.end,
-              ),
-              encryptedText,
-            );
-          });
-          if (!isRekey) {
-            vscode.window.showInformationMessage(
-              `File encrypted: '${doc.fileName}'`,
-            );
+          let decryptedText = await decrypt(
+            vaultTextToDecrypt,
+            pass,
+            vaultId,
+          );
+          status.dispose();
+
+          if (decryptedText === undefined) {
+            vscode.window.showErrorMessage("Decryption failed: Invalid Vault");
+            pass = undefined;
+            continue;
+          } else {
+            await editor.edit((editBuilder) => {
+              editBuilder.replace(selection, decryptedText);
+            });
+            if (!isRekey) {
+              vscode.window.showInformationMessage("Selection decrypted.");
+            }
+            actionDone = true;
           }
         }
-      } else if (type === "encrypted") {
-        logs.appendLine(`🔓 Decrypt entire file`);
-        const status = vscode.window.setStatusBarMessage(
-          "$(loading~spin) Decrypting...",
-        );
-        const decryptedText = await decrypt(content, pass, vaultId);
-        status.dispose();
-        if (decryptedText === undefined) {
-          vscode.window.showErrorMessage("Decryption failed: Invalid Vault");
-        } else {
-          await editor.edit((builder) => {
-            builder.replace(
-              new vscode.Range(
-                doc.lineAt(0).range.start,
-                doc.lineAt(doc.lineCount - 1).range.end,
-              ),
-              decryptedText,
-            );
-          });
-          if (!isRekey) {
-            vscode.window.showInformationMessage(
-              `File decrypted: '${doc.fileName}'`,
-            );
+      } else {
+        const content = editor.document.getText();
+        const type = getTextType(content);
+
+        if (type === "plaintext") {
+          logs.appendLine(`🔒 Encrypt entire file`);
+          const status = vscode.window.setStatusBarMessage(
+            "$(loading~spin) Encrypting...",
+          );
+          const encryptedText = await encrypt(content, pass, vaultId);
+          status.dispose();
+          if (encryptedText) {
+            await editor.edit((builder) => {
+              builder.replace(
+                new vscode.Range(
+                  doc.lineAt(0).range.start,
+                  doc.lineAt(doc.lineCount - 1).range.end,
+                ),
+                encryptedText,
+              );
+            });
+            if (!isRekey) {
+              vscode.window.showInformationMessage(
+                `File encrypted: '${doc.fileName}'`,
+              );
+            }
+          }
+          actionDone = true;
+        } else if (type === "encrypted") {
+          logs.appendLine(`🔓 Decrypt entire file`);
+          const status = vscode.window.setStatusBarMessage(
+            "$(loading~spin) Decrypting...",
+          );
+          let decryptedText = await decrypt(content, pass, vaultId);
+          status.dispose();
+
+          if (decryptedText === undefined) {
+            vscode.window.showErrorMessage("Decryption failed: Invalid Vault");
+            pass = undefined;
+            continue;
+          } else {
+            await editor.edit((builder) => {
+              builder.replace(
+                new vscode.Range(
+                  doc.lineAt(0).range.start,
+                  doc.lineAt(doc.lineCount - 1).range.end,
+                ),
+                decryptedText,
+              );
+            });
+            if (!isRekey) {
+              vscode.window.showInformationMessage(
+                `File decrypted: '${doc.fileName}'`,
+              );
+            }
+            actionDone = true;
           }
         }
       }
@@ -404,7 +418,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 }
 
-export function deactivate() {}
+export function deactivate() { }
 
 const getIndentationLevel = (
   editor: vscode.TextEditor,

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as ini from "ini";
 import * as os from "os";
+import * as child_process from "child_process";
 
 function expandEnvVars(input: string): string {
   return input.replace(/\$(\w+)|\${(\w+)}/g, (_, var1, var2) => {
@@ -182,6 +183,80 @@ export function scanAnsibleCfg(
   return ["", undefined, undefined];
 }
 
+export function isExecutableScript(filePath: string): boolean {
+  try {
+    const stat = fs.statSync(filePath);
+    const isExecutable =
+      (stat.mode & fs.constants.S_IXUSR) !== 0 ||
+      (stat.mode & fs.constants.S_IXGRP) !== 0 ||
+      (stat.mode & fs.constants.S_IXOTH) !== 0;
+
+    if (!isExecutable) {
+      return false;
+    }
+
+    const fd = fs.openSync(filePath, "r");
+    const buffer = Buffer.alloc(2);
+    fs.readSync(fd, buffer, 0, 2, 0);
+    fs.closeSync(fd);
+
+    return buffer.toString("utf-8") === "#!";
+  } catch (e) {
+    return false;
+  }
+}
+
+function executeOrReadFile(
+  logs: vscode.OutputChannel,
+  filePath: string,
+  configFileInWorkspacePath: string,
+): string | undefined {
+  if (isExecutableScript(filePath)) {
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(
+      vscode.Uri.file(configFileInWorkspacePath),
+    );
+    const rootPath = workspaceFolder
+      ? workspaceFolder.uri.fsPath
+      : vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+    const relativeFilePath = rootPath
+      ? path.relative(rootPath, configFileInWorkspacePath)
+      : path.basename(configFileInWorkspacePath);
+
+    try {
+      const cwd = rootPath || path.dirname(configFileInWorkspacePath);
+      const result = child_process.spawnSync(filePath, [relativeFilePath], {
+        encoding: "utf-8",
+        cwd,
+      });
+
+      if (result.stderr && result.stderr.trim().length > 0) {
+        logs.appendLine(`[Script stderr] ${filePath}:\n${result.stderr.trim()}`);
+      }
+
+      if (result.error) {
+        logs.appendLine(`[Script error] ${filePath}: ${result.error.message}`);
+        return undefined;
+      }
+
+      if (result.status !== 0) {
+        logs.appendLine(`[Script exit] ${filePath} exited with status ${result.status}`);
+      }
+
+      if (result.stdout !== undefined && result.stdout !== null) {
+        return result.stdout.trim().replace(/[\n\r\t]/gm, "");
+      }
+      return undefined;
+    } catch (e: any) {
+      logs.appendLine(`[Script exception] ${filePath}: ${e.message}`);
+      return undefined;
+    }
+  }
+
+  const content = fs.readFileSync(filePath, "utf-8").trim();
+  return content.replace(/[\n\r\t]/gm, "");
+}
+
 export function findPassword(
   logs: vscode.OutputChannel,
   configFileInWorkspacePath: string,
@@ -190,8 +265,7 @@ export function findPassword(
   const expandedPassFile = expandAll(vaultPassFile.trim());
 
   if (fs.existsSync(expandedPassFile)) {
-    const content = fs.readFileSync(expandedPassFile, "utf-8").trim();
-    return content.replace(/[\n\r\t]/gm, "");
+    return executeOrReadFile(logs, expandedPassFile, configFileInWorkspacePath);
   }
 
   const passPath = findAnsibleCfgFile(
@@ -199,7 +273,11 @@ export function findPassword(
     configFileInWorkspacePath,
     expandedPassFile,
   );
-  return readFile(passPath);
+  
+  if (passPath && fs.existsSync(passPath)) {
+    return executeOrReadFile(logs, passPath, configFileInWorkspacePath);
+  }
+  return undefined;
 }
 
 export function readFile(filePath: string | undefined): string | undefined {


### PR DESCRIPTION
- Added logic to detect if vault_password_file is an executable script (e.g. chmod +x and has a #! magic line).
- Executes the script and dynamically uses its stdout as the vault password.
- Passes the target file's relative path as the first argument to the script, enabling path-based password logic.
- Captures any script stderr output and logs it directly to the extension's VS Code Output channel for better debug visibility.

fix: Graceful decryption fallback

- Refactored the encryption/decryption loop so that if the provided password (from a script or config) fails to decrypt the file, the extension gracefully falls back and automatically prompts the user via the password input dialog to try again.

docs: Update README with advanced script examples

- Added documentation outlining the new executable script feature. Included a comprehensive, collapsible example of a dynamic vault_password.sh script that chooses different passwords based on the environment and file path.
- Add changelog entry

Bump packages.json version to 1.4.0

- [ ] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/ipierre1/ansible-vault-vscode/blob/main/CHANGELOG.md
